### PR TITLE
Fix having multiple plugins, with different color schemes.

### DIFF
--- a/src/main/java/org/avarion/pluginhider/exceptions/SectionExpectedException.java
+++ b/src/main/java/org/avarion/pluginhider/exceptions/SectionExpectedException.java
@@ -1,0 +1,7 @@
+package org.avarion.pluginhider.exceptions;
+
+public class SectionExpectedException extends IllegalStateException {
+    public SectionExpectedException() {
+        super("Expected to see a section first!");
+    }
+}

--- a/src/main/java/org/avarion/pluginhider/util/ReceivedPackets.java
+++ b/src/main/java/org/avarion/pluginhider/util/ReceivedPackets.java
@@ -7,6 +7,7 @@ import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
 import org.avarion.pluginhider.PluginHider;
+import org.avarion.pluginhider.exceptions.SectionExpectedException;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -18,7 +19,7 @@ import java.util.regex.Pattern;
 
 
 public class ReceivedPackets {
-    private final static Pattern amountPluginsPattern = Pattern.compile("\\(\\s*(\\d+)\\s*\\)\\s*:\\s*$");
+    private static final Pattern amountPluginsPattern = Pattern.compile("\\(\\s*(\\d+)\\s*\\)\\s*:\\s*$");
     private final HashMap<net.kyori.adventure.text.TextComponent, List<String>> pluginsSeen = new LinkedHashMap<>();
     public Integer amountOfPlugins = null;
     private net.kyori.adventure.text.TextComponent currentSection = null;
@@ -49,7 +50,7 @@ public class ReceivedPackets {
             currentSection = tc;
         }
         else if (currentSection == null) {
-            throw new RuntimeException("I expected to see a section first!");
+            throw new SectionExpectedException();
         }
         else {
             interpretPluginLine(line);

--- a/src/main/java/org/avarion/pluginhider/util/ReceivedPackets.java
+++ b/src/main/java/org/avarion/pluginhider/util/ReceivedPackets.java
@@ -1,38 +1,55 @@
 package org.avarion.pluginhider.util;
 
+import io.github.retrooper.packetevents.adventure.serializer.gson.GsonComponentSerializer;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import org.avarion.pluginhider.PluginHider;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
 public class ReceivedPackets {
-    private final static Pattern amountPluginsPattern = Pattern.compile("\\(\\s*(\\d+)\\s*\\):");
-    private final List<String> pluginsSeen = new ArrayList<>();
-
+    private final static Pattern amountPluginsPattern = Pattern.compile("\\(\\s*(\\d+)\\s*\\)\\s*:\\s*$");
+    private final HashMap<net.kyori.adventure.text.TextComponent, List<String>> pluginsSeen = new LinkedHashMap<>();
     public Integer amountOfPlugins = null;
+    private net.kyori.adventure.text.TextComponent currentSection = null;
     private int lineCounter = 0;
 
-    public void addSystemChatLine(final String line) {
+    private @NotNull String asString(final @NotNull net.kyori.adventure.text.TextComponent line) {
+        StringBuilder sb = new StringBuilder();
+        asString(line, sb);
+        return sb.toString();
+    }
+
+    private void asString(final @NotNull net.kyori.adventure.text.TextComponent line, final @NotNull StringBuilder sb) {
+        sb.append(line.content());
+        for (var component : line.children()) {
+            assert component instanceof net.kyori.adventure.text.TextComponent;
+            asString((net.kyori.adventure.text.TextComponent) component, sb);
+        }
+    }
+
+    public void addSystemChatLine(final net.kyori.adventure.text.TextComponent tc) {
         lineCounter++;
 
+        final String line = asString(tc);
         if (lineCounter == 1) {
             interpretAmountOfPlugins(line);
         }
-        else if (lineCounter == 2) {
-            if (!line.endsWith(":")) {
-                throw new IllegalArgumentException("Invalid 'Bukkit' line: " + line);
-            }
+        else if (line.endsWith(":")) {
+            currentSection = tc;
+        }
+        else if (currentSection == null) {
+            throw new RuntimeException("I expected to see a section first!");
         }
         else {
             interpretPluginLine(line);
@@ -46,7 +63,8 @@ public class ReceivedPackets {
         }
         String[] parts = fullText.split(",");
 
-        pluginsSeen.addAll(Arrays.stream(parts).map(String::trim).filter(p -> !p.isEmpty()).toList());
+        var arr = pluginsSeen.computeIfAbsent(currentSection, s -> new ArrayList<>());
+        arr.addAll(Arrays.stream(parts).map(String::trim).filter(p -> !p.isEmpty()).toList());
     }
 
     private void interpretAmountOfPlugins(final String line) {
@@ -56,28 +74,42 @@ public class ReceivedPackets {
         }
     }
 
+    private <K, V> int size(@NotNull Map<K, List<V>> map) {
+        return map.values().stream().mapToInt(List::size).sum();
+    }
+
     public boolean isFinished() {
-        return amountOfPlugins != null && pluginsSeen.size() >= amountOfPlugins;
+        return amountOfPlugins != null && size(pluginsSeen) >= amountOfPlugins;
     }
 
     // region <Message sending>
     public void sendModifiedMessage(@NotNull Player player) {
         final Player.Spigot pl = player.spigot();
 
-        List<String> newPlugins = pluginsSeen.stream().filter(PluginHider.config::shouldShow).toList();
+        HashMap<net.kyori.adventure.text.TextComponent, List<String>> filtered = new HashMap<>();
+        for (var entry : pluginsSeen.entrySet()) {
+            List<String> filteredList = entry.getValue().stream().filter(PluginHider.config::shouldShow).toList();
 
-        TextComponent msg = createFirstLine(newPlugins.size());
+            if (!filteredList.isEmpty()) {
+                filtered.put(entry.getKey(), filteredList);
+            }
+        }
+
+        int total = size(filtered);
+        TextComponent msg = createFirstLine(total);
         pl.sendMessage(msg);
 
-        if (newPlugins.isEmpty()) {
+        if (total <= 0) {
             return;
         }
 
-        msg = createSecondLine();
-        pl.sendMessage(msg);
+        for (var entry : filtered.entrySet()) {
+            var header = createSecondLine(entry.getKey(), entry.getValue().size());
+            pl.sendMessage(header);
 
-        msg = createThirdLine(newPlugins);
-        pl.sendMessage(msg);
+            msg = createThirdLine(entry.getValue());
+            pl.sendMessage(msg);
+        }
     }
 
     private @NotNull TextComponent createFirstLine(int amount) {
@@ -86,11 +118,18 @@ public class ReceivedPackets {
         return msg;
     }
 
-    private @NotNull TextComponent createSecondLine() {
-        TextComponent msg = new TextComponent("Bukkit Plugins:");
-        msg.setColor(net.md_5.bungee.api.ChatColor.of("#ed8106"));
+    private @NotNull BaseComponent createSecondLine(final @NotNull net.kyori.adventure.text.TextComponent section, int count) {
+        String line = asString(section);
+        Matcher match = amountPluginsPattern.matcher(line);
 
-        return msg;
+        net.kyori.adventure.text.Component msg = section;
+        if (match.find()) {
+            // Change plugin count
+            msg = section.replaceText(builder -> builder.match(amountPluginsPattern).replacement("(" + count + "):"));
+        }
+
+        String json = GsonComponentSerializer.gson().serialize(msg);
+        return ComponentSerializer.parse(json)[0];
     }
 
     private @NotNull TextComponent createThirdLine(final @NotNull List<String> plugins) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,4 +14,4 @@ commands:
   pluginhider:
     description: Reloads the PluginHiders configuration
     usage: /pluginhider reload
-    aliases: [ph]
+    aliases: [ ph ]


### PR DESCRIPTION
Tested with:
```
[17:38:02 INFO]: [PluginInitializerManager] Initialized 6 plugins
[17:38:02 INFO]: [PluginInitializerManager] Paper plugins (1):
 - SingleMace (1.0-SNAPSHOT)
[17:38:02 INFO]: [PluginInitializerManager] Bukkit plugins (5):
 - ItemsAdder (4.0.5), LoneLibs (1.0.62), ProtocolLib (5.4.0-SNAPSHOT-738), packetevents (2.7.0), pluginhider (0.0.0)
```

Now supports this new format, also supports colors.