### PR TITLE
ci: declare minimal GITHUB_TOKEN permissions on workflows

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -8,6 +8,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
CodeQL flagged both workflow files with:

> Workflow does not contain permissions
> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: `{contents: read}`

This PR adds a top-level `permissions: contents: read` block to both workflows so the `GITHUB_TOKEN` defaults to read-only. The release workflow's job-level `contents: write, packages: write` is preserved (job-level overrides workflow-level), so the publish step still has the access it needs.

## Test plan
- [ ] CodeQL "Analyze (actions)" passes on this PR
- [ ] Build workflow still runs successfully